### PR TITLE
Adding missing dependencies on javafx.*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,21 @@
             <version>4.9</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>11</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Building openchemlib on Debian 'unstable' with maven fails due to missing symbols:
```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /<<PKGBUILDDIR>>/src/main/java/com/actelion/research/jfx/gui/chem/MoleculeViewSkin.java:[57,28] package javafx.scene.control does not exist
[ERROR] /<<PKGBUILDDIR>>/src/main/java/com/actelion/research/jfx/gui/chem/MoleculeViewSkin.java:[73,16] cannot find symbol
```
This PR adds the missing dependencies on javafx.* artifacts.