### PR TITLE
Extend metal atom set

### DIFF
--- a/src/main/java/com/actelion/research/chem/Molecule.java
+++ b/src/main/java/com/actelion/research/chem/Molecule.java
@@ -4099,7 +4099,7 @@ public class Molecule implements Serializable {
 			|| (atomicNo >= 19 && atomicNo <= 31)
 			|| (atomicNo >= 37 && atomicNo <= 51)
 			|| (atomicNo >= 55 && atomicNo <= 84)
-			|| (atomicNo >= 87 && atomicNo <= 103);
+			|| (atomicNo >= 87 && atomicNo <= 112);
 		}
 
 

--- a/src/main/java/com/actelion/research/chem/Molecule.java
+++ b/src/main/java/com/actelion/research/chem/Molecule.java
@@ -4085,7 +4085,7 @@ public class Molecule implements Serializable {
 
 			if (mAtomList != null && mAtomList[atom] != null)
 				for (int atomicNo:mAtomList[atom])
-					if (!isAtomicNoMetal(atomicNo))
+					if (!isAtomicNoTransitionMetal(atomicNo))
 						return false;
 			}
 


### PR DESCRIPTION
Elements 104-112 were recognised as transition metals, but not as metals (compare the atom number sets in `isAtomicNoMetal()` and `isAtomicNoTransitionMetal()`). 