### PR TITLE
Delete and recreate the build directory on each run

### DIFF
--- a/buildOpenChemLib
+++ b/buildOpenChemLib
@@ -2,7 +2,8 @@
 # Builds OpenChemLib.jar from a shell
 # OpenChemLib does not require any dependency
 #
-rm -rf ./build/*
+rm -rf ./build
+mkdir build
 cp -r ./src/main/resources/* ./build/
 find . -name "*.java" > sources.txt
 javac -d ./build @sources.txt


### PR DESCRIPTION
The previous version of the build script failed unless a "build" directory was already present. Completely removing and recreating this directory on each run should be equivalent to removing its contents on each run.