### PR TITLE
set tool before redrawing when tool is changed

### DIFF
--- a/src/main/java/com/actelion/research/gui/editor/GenericEditorArea.java
+++ b/src/main/java/com/actelion/research/gui/editor/GenericEditorArea.java
@@ -592,10 +592,11 @@ public class GenericEditorArea implements GenericEventListener {
 		if (mCurrentTool != newTool) {
 			if (mCurrentTool == GenericEditorToolbar.cToolMapper
 					|| newTool == GenericEditorToolbar.cToolMapper) {
+				mCurrentTool = newTool;
 				update(UPDATE_REDRAW);
+			} else {
+				mCurrentTool = newTool;
 			}
-
-			mCurrentTool = newTool;
 		}
 	}
 


### PR DESCRIPTION
This fixes a redraw inconsistency when the `update` implementation is synchronous.
In that case, the drawing would happen before the tool is actually changed.
