### PR TITLE
fix: double click event handling (in DOM environments)

### DIFF
--- a/src/main/java/com/actelion/research/gui/editor/GenericEditorArea.java
+++ b/src/main/java/com/actelion/research/gui/editor/GenericEditorArea.java
@@ -979,14 +979,18 @@ public class GenericEditorArea implements GenericEventListener {
 			}
 
 			if (e.getButton() == 1) {
+				mMouseIsDown = false;
+				updateCursor();
+				mouseReleasedButton1();
+			}
+		}
+
+		if (e.getWhat() == GenericMouseEvent.MOUSE_CLICKED) {
+			if (e.getButton() == 1) {
 				if (e.getClickCount() == 2) {
 					handleDoubleClick(e.getX(), e.getY());
 					return;
 				}
-
-				mMouseIsDown = false;
-				updateCursor();
-				mouseReleasedButton1();
 			}
 		}
 


### PR DESCRIPTION
It's needed for https://github.com/cheminfo/openchemlib-js project

DOM `pointerdown` and `pointerup` do not contain number of click in `detail` like `click` events.
So I tweak `GenericEditorArea.eventHappened` to call `handleDoubleClick` on `GenericMouseEvent.MOUSE_CLICKED`

Refs: https://github.com/cheminfo/openchemlib-js/pull/232