### PR TITLE
Use callbacks to handle generic dialog lifecycle

### DIFF
--- a/src/main/java/com/actelion/research/gui/editor/AtomQueryFeatureDialogBuilder.java
+++ b/src/main/java/com/actelion/research/gui/editor/AtomQueryFeatureDialogBuilder.java
@@ -135,14 +135,12 @@ public class AtomQueryFeatureDialogBuilder implements GenericEventListener<Gener
 		}
 
 	/**
-	 * @return true if OK was pressed and potential change was applied to molecule
+	 * Show the dialog and call back with true if OK was pressed and potential change was applied to molecule
 	 */
-	public boolean showDialog() {
+	public void showDialog(DialogBuilderCallback cb) {
 		mOKSelected = false;
-		mDialog.showDialog();
-
-		return mOKSelected;
-		}
+		mDialog.showDialog(() -> cb.onClose(mOKSelected));
+	}
 
 	private void build(ExtendedMolecule mol, int atom, boolean includeReactionHints) {
 		mMol = mol;

--- a/src/main/java/com/actelion/research/gui/editor/BondQueryFeatureDialogBuilder.java
+++ b/src/main/java/com/actelion/research/gui/editor/BondQueryFeatureDialogBuilder.java
@@ -55,13 +55,12 @@ public class BondQueryFeatureDialogBuilder implements GenericEventListener<Gener
 		}
 
 	/**
-	 * @return true if OK was pressed and potential change was applied to molecule
+	 * Show the dialog and call back with true if OK was pressed and potential change was applied to molecule
 	 */
-	public boolean showDialog() {
+	public void showDialog(DialogBuilderCallback cb) {
 		mOKSelected = false;
-		mDialog.showDialog();
-		return mOKSelected;
-		}
+		mDialog.showDialog(() -> cb.onClose(mOKSelected));
+	}
 
 	private void build(ExtendedMolecule mol, int bond) {
 		mMol = mol;

--- a/src/main/java/com/actelion/research/gui/editor/CustomAtomDialogBuilder.java
+++ b/src/main/java/com/actelion/research/gui/editor/CustomAtomDialogBuilder.java
@@ -79,13 +79,12 @@ public class CustomAtomDialogBuilder implements GenericEventListener<GenericActi
 		}
 
 	/**
-	 * @return true if OK was pressed and potential change was applied to molecule
+	 * Show the dialog and call back with true if OK was pressed and potential change was applied to molecule
 	 */
-	public boolean showDialog() {
+	public void showDialog(DialogBuilderCallback cb) {
 		mOKSelected = false;
-		mDialog.showDialog();
-		return mOKSelected;
-		}
+		mDialog.showDialog(() -> cb.onClose(mOKSelected));
+	}
 
 	private void build() {
         int[] hLayout = {8, GenericDialog.PREFERRED, 8, GenericDialog.PREFERRED, 8 };

--- a/src/main/java/com/actelion/research/gui/editor/DialogBuilderCallback.java
+++ b/src/main/java/com/actelion/research/gui/editor/DialogBuilderCallback.java
@@ -1,0 +1,5 @@
+package com.actelion.research.gui.editor;
+
+public interface DialogBuilderCallback {
+    void onClose(boolean okSelected);
+}

--- a/src/main/java/com/actelion/research/gui/editor/GenericEditorToolbar.java
+++ b/src/main/java/com/actelion/research/gui/editor/GenericEditorToolbar.java
@@ -215,8 +215,9 @@ public class GenericEditorToolbar implements GenericEventListener {
 						        : (mESRSelected == 1) ? cToolESRAnd : cToolESROr);
 	            }
 	        else if (mCurrentTool == cToolCustomAtom) {
-	        	mArea.showCustomAtomDialog(-1);
-		        mArea.toolChanged(releasedButton);
+				mArea.showCustomAtomDialog(-1, () -> {
+					mArea.toolChanged(releasedButton);
+					});
 	            }
 	        else {
 		        mArea.toolChanged(releasedButton);

--- a/src/main/java/com/actelion/research/gui/editor/TextDrawingObjectDialogBuilder.java
+++ b/src/main/java/com/actelion/research/gui/editor/TextDrawingObjectDialogBuilder.java
@@ -58,13 +58,12 @@ public class TextDrawingObjectDialogBuilder implements GenericEventListener<Gene
 		}
 
 	/**
-	 * @return true if OK was pressed and potential change was applied to molecule
+	 * Show the dialog and call back with true if OK was pressed and potential change was applied to molecule
 	 */
-	public boolean showDialog() {
+	public void showDialog(DialogBuilderCallback cb) {
 		mOKSelected = false;
-		mDialog.showDialog();
-		return mOKSelected;
-		}
+		mDialog.showDialog(() -> cb.onClose(mOKSelected));
+	}
 
 	private void build() {
         mComboBoxTextSize = mDialog.createComboBox();

--- a/src/main/java/com/actelion/research/gui/fx/FXDialog.java
+++ b/src/main/java/com/actelion/research/gui/fx/FXDialog.java
@@ -76,8 +76,9 @@ public class FXDialog extends Dialog<String> implements GenericDialog {
 	}
 
 	@Override
-	public void showDialog() {
+	public void showDialog(GenericDialogCallback cb) {
 		showAndWait();
+		cb.onClose();
 	}
 
 	@Override

--- a/src/main/java/com/actelion/research/gui/generic/GenericDialog.java
+++ b/src/main/java/com/actelion/research/gui/generic/GenericDialog.java
@@ -14,7 +14,7 @@ public interface GenericDialog {
 	GenericLabel createLabel(String text);
 	GenericTextField createTextField(int width, int height);
 	void setEventConsumer(GenericEventListener<GenericActionEvent> consumer);
-	void showDialog();  // must wait until OK or Cancel is pressed
+    void showDialog(GenericDialogCallback cb); // Callback must be called after the dialog is closed.
 	void disposeDialog();
 	void showMessage(String message);
 }

--- a/src/main/java/com/actelion/research/gui/generic/GenericDialogCallback.java
+++ b/src/main/java/com/actelion/research/gui/generic/GenericDialogCallback.java
@@ -1,0 +1,5 @@
+package com.actelion.research.gui.generic;
+
+public interface GenericDialogCallback {
+	void onClose();
+}

--- a/src/main/java/com/actelion/research/gui/swing/SwingDialog.java
+++ b/src/main/java/com/actelion/research/gui/swing/SwingDialog.java
@@ -59,7 +59,7 @@ public class SwingDialog extends JDialog implements ActionListener,GenericDialog
 	}
 
 	@Override
-	public void showDialog() {
+	public void showDialog(GenericDialogCallback cb) {
 		JPanel buttonpanel = new JPanel();
 		int gap = HiDPIHelper.scale(8);
 		buttonpanel.setBorder(BorderFactory.createEmptyBorder(gap*3/2, gap, gap, gap));
@@ -81,6 +81,7 @@ public class SwingDialog extends JDialog implements ActionListener,GenericDialog
 		pack();
 		setLocationRelativeTo(mParent);
 		setVisible(true);
+		cb.onClose();
 		}
 
 	@Override


### PR DESCRIPTION
In JavaScript, it is not possible to have the `showDialog` method block execution until the dialog is closed. This is because there is a single JS execution thread shared wiwth the browser's renderer thread. Change the generic `showDialog` APIs to expect a callback that must be called after the dialog has been closed by user interaction and execute further processing in the callback.