### PR TITLE
add additional thread cancellation checks

### DIFF
--- a/src/main/java/com/actelion/research/chem/reaction/mapping/ChemicalRuleEnhancedReactionMapper.java
+++ b/src/main/java/com/actelion/research/chem/reaction/mapping/ChemicalRuleEnhancedReactionMapper.java
@@ -208,10 +208,15 @@ public class ChemicalRuleEnhancedReactionMapper implements IReactionMapper {
 		}
 
 	/**
-	 * @param rxn
+	 * @param rxn reaction to be mapped
 	 * @return false if reaction wasn't mapped, e.g. due to interruption by threadmaster
 	 */
 	public boolean map(Reaction rxn) {
+        // Fail fast if the thread was canceled before starting.
+        if (mThreadMaster != null && mThreadMaster.threadMustDie()) {
+            return false;
+        }
+
 		initialize();
 		SimilarityGraphBasedReactionMapper mapper = new SimilarityGraphBasedReactionMapper();
 		mapper.setThreadMaster(mThreadMaster);
@@ -241,7 +246,7 @@ if (SimilarityGraphBasedReactionMapper.DEBUG)
 
 		StereoMolecule adaptedReactant = new StereoMolecule(); // reusable container
 
-		for (ChemicalRule rule:sChemicalRule) {
+        for (ChemicalRule rule:sChemicalRule) {
 			if (ruleApplicationCount++ == mMaxRuleTries || (mThreadMaster != null && mThreadMaster.threadMustDie()))
 				break;
 
@@ -254,7 +259,7 @@ if (SimilarityGraphBasedReactionMapper.DEBUG)
 float historyScore = -10000;
 					int[] productMatch = productSearcher.getMatchList().get(0);
 					for (int[] reactantMatch:reactantSearcher.getMatchList()) {
-						if (ruleApplicationCount++ >= mMaxRuleTries)
+                        if (ruleApplicationCount++ >= mMaxRuleTries || (mThreadMaster != null && mThreadMaster.threadMustDie()))
 							break;
 
 						// For every given rule we check, whether we can apply the rule and whether we get a mapping score better than anything else:

--- a/src/main/java/com/actelion/research/chem/reaction/mapping/SimilarityGraphBasedReactionMapper.java
+++ b/src/main/java/com/actelion/research/chem/reaction/mapping/SimilarityGraphBasedReactionMapper.java
@@ -110,7 +110,12 @@ public class SimilarityGraphBasedReactionMapper {
 	 * @return false if reaction wasn't mapped due to interruption by threadmaster
 	 */
 	public boolean map(StereoMolecule reactant, StereoMolecule product, int[] reactantMapNo, int[] productMapNo, boolean[][] vetoMatrix) {
-		mReactant = reactant;
+        // Fail fast if the thread was canceled before starting.
+        if (mThreadMaster != null && mThreadMaster.threadMustDie()) {
+            return false;
+        }
+
+        mReactant = reactant;
 		mProduct = product;
 
 		mReactantMapNo = new int[reactantMapNo.length];
@@ -138,7 +143,7 @@ public class SimilarityGraphBasedReactionMapper {
 			int mappableAtomCount = rootAtomPairSource.getMappableAtomCount();
 
 			RootAtomPair pair = rootAtomPairSource.nextPair();
-			while (pair != null) {
+			while (pair != null && (mThreadMaster == null || !mThreadMaster.threadMustDie())) {
 if (PRINT_SCORES)  { System.out.println(); System.out.println("@ SMapper.map() pair: "+pair.reactantAtom+","+pair.productAtom+" mMapNo:"+mMapNo+" sequence:"+mAtomPairSequenceCount); }
 				mapFromRootAtoms(pair);
 if (PRINT_SCORES)  { System.out.print("@ rMapNo:"); for (int mapNo:mReactantMapNo) System.out.print(" "+mapNo); System.out.println(); }


### PR DESCRIPTION
Add thread cancellation checks to
- the beginning and
- inner loops
of reaction mapping methods to handle interruptions more responsively.