### PR TITLE
Fix molfile header to include 2D/3D dimension label

### DIFF
--- a/src/main/java/com/actelion/research/chem/MolfileCreator.java
+++ b/src/main/java/com/actelion/research/chem/MolfileCreator.java
@@ -128,7 +128,7 @@ public class MolfileCreator {
 
         String name = (mol.getName() != null) ? mol.getName() : "";
         mBuilder.append(name+nl);
-        mBuilder.append("Actelion Java MolfileCreator 1.0"+nl+nl);
+        mBuilder.append("OCL MolfileCreator   " + (mol.is3D() ? "3D" : "2D") + nl+nl);
 
         appendThreeDigitInt(mol.getAllAtoms());
         appendThreeDigitInt(mol.getAllBonds());

--- a/src/main/java/com/actelion/research/chem/MolfileV3Creator.java
+++ b/src/main/java/com/actelion/research/chem/MolfileV3Creator.java
@@ -112,7 +112,7 @@ public class MolfileV3Creator
 
 		String name = (mol.getName() != null) ? mol.getName() : "";
 		mMolfile.append(name + nl);
-		mMolfile.append("Actelion Java MolfileCreator 2.0"+nl+nl);
+		mMolfile.append("OCL MolfileCreator   " + (mol.is3D() ? "3D" : "2D") + nl+nl);
 		mMolfile.append("  0  0  0  0  0  0              0 V3000"+nl);
 
 		mScalingFactor = 1.0;


### PR DESCRIPTION
## Summary

Update the program line (line 2) of molfile output in both `MolfileCreator` and `MolfileV3Creator` to properly indicate the molecule's dimensionality:

- `OCL MolfileCreator   2D` when `mol.is3D()` is false
- `OCL MolfileCreator   3D` when `mol.is3D()` is true

This places the 2D/3D indicator at positions 20-21 of the header line per the MDL molfile specification.

## Motivation

Modeling software that reads SDF/molfiles expects the dimension flag at the standard position on line 2. The previous header (`Actelion Java MolfileCreator 1.0` / `2.0`) did not include this, causing compatibility issues when converting from DataWarrior/OCL to SDF for use in other tools.

## Changes

- `MolfileCreator.java` — replaced static header with dynamic 2D/3D label based on `mol.is3D()`
- `MolfileV3Creator.java` — same change

## Testing

Project compiles successfully with `mvn compile`.
